### PR TITLE
All resources improvements

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -17,6 +17,8 @@ subitems:
     subitems:
       - title: Contributor page
         url: /contributors.html
+      - title: All resources
+        url: /all_resources.html
       - title: Events
         url: /events.html
       - title: News page

--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -1,4 +1,3 @@
-Tools:
 - description: Bioconda is a bioinformatics channel for the Conda package manager
   link: https://bioconda.github.io/
   name: Bioconda

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -1,6 +1,8 @@
-{%- assign tools = site.data.tool_and_resource_list.Tools | where:"related_pages", include.tag %}
+{%- assign tools = site.data.tool_and_resource_list | where:"related_pages", include.tag %}
 {%- unless tools.size == 0 %}
+{%- if include.tag -%}
 <h2>Relevant tools and resources</h2>
+{%- endif %}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
 <div class="table-responsive mt-4 mb-5">
     <table id="tooltable" class="table display">
@@ -26,7 +28,7 @@
                 {%- assign total_county_tools = 0 %}
                 {%- assign instances_tool = 0 %}
                 {%- assign query = "related_pages." | append: page.type %}
-                {%- assign country_pages = site.pages | where: "type", "national_resources" | where: "search_exclude", "false" %}
+                {%- assign country_pages = site.pages | where: "search_exclude", "false" | where_exp:"item","item.resources != nil" %}
                 {%- for country_page in country_pages %}
                 {%- assign instance_matches = country_page.resources | where: "instance_of", tool.name | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
                 {%- assign tool_matches = country_page.resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
@@ -91,7 +93,7 @@
             {%- for tool in tool_matches %}
             {%- assign tool_id = tool.name | slugify %}
             {%- assign hide_ids = hide_ids | append: " " | append: tool_id %}
-            <tr class="collapse multi-collapse" id="{{tool_id}}">
+            <tr {% unless include.tag == nil %} class="collapse multi-collapse" id="{{tool_id}}"{% endunless %}>
                 {% if tool.url %}
                 <td><a href="{{tool.url}}">{{tool.name}}</a><a href="{{country_page.url}}" data-bs-toggle="tooltip" title="{{country_page.title}}"><span class="flag-icon ms-2 flag-icon-{{country_page.country_code | downcase }}"></span></a></td>
                 {%- else %}
@@ -131,7 +133,7 @@
         </tbody>
     </table>
 </div>
-{%- unless total_county_tools == 0 %}
+{%- unless total_county_tools == 0 or include.tag == nil %}
 <a class="btn btn-primary" id="national-resources-button" data-bs-toggle="collapse" data-bs-target=".multi-collapse" role="button" aria-expanded="false" aria-controls="{{hide_ids}}">
     View national resources <span class="badge bg-white text-primary ms-2">{{total_county_tools}}</span>
   </a>

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -1,6 +1,7 @@
 {%- assign tools = site.data.tool_and_resource_list | where:"related_pages", include.tag %}
+{%- assign country_pages = site.pages | where_exp: "item", "item.search_exclude != true" | where_exp:"item","item.resources != nil" %}
 {%- unless tools.size == 0 %}
-{%- if include.tag -%}
+{%- if include.tag %}
 <h2>Relevant tools and resources</h2>
 {%- endif %}
 <a class="visually-hidden-focusable" href='#skip-tool-table'>Skip tool table</a>
@@ -28,7 +29,6 @@
                 {%- assign total_county_tools = 0 %}
                 {%- assign instances_tool = 0 %}
                 {%- assign query = "related_pages." | append: page.type %}
-                {%- assign country_pages = site.pages | where: "search_exclude", "false" | where_exp:"item","item.resources != nil" %}
                 {%- for country_page in country_pages %}
                 {%- assign instance_matches = country_page.resources | where: "instance_of", tool.name | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
                 {%- assign tool_matches = country_page.resources | where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
@@ -89,7 +89,11 @@
             {%- endunless %}
             {%- assign hide_ids = "resource_title" %}
             {%- for country_page in country_pages %}
+            {%- if include.tag %}
             {%- assign tool_matches = country_page.resources| where_exp:"resource","resource.related_pages != nil" | where: query, include.tag %}
+            {%- else %}
+            {%- assign tool_matches = country_page.resources %}
+            {%- endif %}
             {%- for tool in tool_matches %}
             {%- assign tool_id = tool.name | slugify %}
             {%- assign hide_ids = hide_ids | append: " " | append: tool_id %}

--- a/_includes/resource-table-all.html
+++ b/_includes/resource-table-all.html
@@ -45,7 +45,7 @@
                 <td>{{tool.name}}</td>
                 {%- endif %}
                 <td>{{tool.description}}
-                {%- unless instances_tool == 0 or total_county_tools == 0 %}
+                {%- unless instances_tool == 0 or total_county_tools == 0 or include.tag == nil %}
                 <a href="#national-resources-button" class="d-block mt-1">
                 <span class="badge text-white bg-primary"><i class="fas fa-arrow-circle-down me-2"></i>Different instances available</span>
                 </a>

--- a/pages/example_pages/all_resources.md
+++ b/pages/example_pages/all_resources.md
@@ -1,7 +1,7 @@
 ---
 title: Overview page example
 toc: false
-
+datatable: true
 ---
 
 Nam non sollicitudin sapien. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas consectetur nulla nec rutrum rhoncus. Sed non urna sem. Maecenas sed lobortis urna, hendrerit aliquet massa. Phasellus felis dui, feugiat ut sapien vel, mattis dictum eros. Suspendisse in felis sit amet dui elementum rutrum tristique eget velit. Sed hendrerit, ante sit amet hendrerit cursus, ante nibh accumsan nibh, vitae rhoncus quam ipsum placerat ante.

--- a/pages/example_pages/all_resources.md
+++ b/pages/example_pages/all_resources.md
@@ -1,0 +1,20 @@
+---
+title: Overview page example
+toc: false
+
+---
+
+Nam non sollicitudin sapien. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Maecenas consectetur nulla nec rutrum rhoncus. Sed non urna sem. Maecenas sed lobortis urna, hendrerit aliquet massa. Phasellus felis dui, feugiat ut sapien vel, mattis dictum eros. Suspendisse in felis sit amet dui elementum rutrum tristique eget velit. Sed hendrerit, ante sit amet hendrerit cursus, ante nibh accumsan nibh, vitae rhoncus quam ipsum placerat ante.
+
+## Listing all resources
+
+
+```
+{% raw %}
+{% include resource-table-all.html %}
+{% endraw %}
+```
+
+
+{% include resource-table-all.html %}
+


### PR DESCRIPTION
- Example page for all tools and resources
- Bug fixed: national resource did not show up in all tools and resources if it did not have a related page
- country pages only one time assigned
- No title "<h2>Relevant tools and resources</h2>  " when not filtering on a tag